### PR TITLE
Drop void in favour of dcat

### DIFF
--- a/spec/section/logical-target-in-rml.md
+++ b/spec/section/logical-target-in-rml.md
@@ -43,7 +43,7 @@ are exported to the default target of the processor.
 In the example below, a CSV file is transformed into a knowledge graph.
 The CSV file is accessed using the [[CSVW]] vocabulary,
 transformed into a knowledge graph using [[RML]] mappings,
-and exported to two Logical Targets, which are accessed through the [[VoID]] 
+and exported to two Logical Targets, which are accessed through the [[DCAT]] 
 vocabulary.
 The knowledge graph is exported as N-Quads to the first Target,
 and as Turtle to the second Target.
@@ -104,23 +104,23 @@ id;name;nickname
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump2&gt;;
+  rml:target &lt;#DCATDump2&gt;;
   rml:serialization formats:Turtle;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a void:Dataset;
-  void:dataDump &ltfile:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a dcat:Distribution;
+  dcat:downloadURL &ltfile:///data/dump1.nt&gt;;
 .
 
-&lt;#VoIDDump2&gt; a void:Dataset;
-  void:dataDump &ltfile:///data/dump2.ttl.zip&gt;;
+&lt;#DCATDump2&gt; a dcat:Distribution;
+  dcat:downloadURL &ltfile:///data/dump2.ttl.zip&gt;;
   rml:compression rml:zip;
 .
 </pre>

--- a/spec/section/multiple-targets.md
+++ b/spec/section/multiple-targets.md
@@ -74,30 +74,30 @@ to the three specified Targets:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:JSON-LD;
 .
 &lt;#TargetDump3&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:RDF_XML;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt.zip&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt.zip&gt;;
   rml:compression rml:zip;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.jsonld.tar.xz&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.jsonld.tar.xz&gt;;
   rml:compression rml:tarxz;
 .
-&lt;#VoIDDump3&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump3.rdf.tar.gz&gt;;
+&lt;#DCATDump3&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump3.rdf.tar.gz&gt;;
   rml:compression rml:targz;
 .
 </pre>
@@ -231,21 +231,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a void:Dataset ;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -334,21 +334,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -437,21 +437,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -537,21 +537,21 @@ predicate `foaf:nickname` are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -643,21 +643,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nq&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nq&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nq&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nq&gt;;
 .
 </pre>
 
@@ -749,21 +749,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nq&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nq&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump2.nq&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump2.nq&gt;;
 .
 </pre>
 
@@ -851,21 +851,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nq&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nq&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nq&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nq&gt;;
 .
 </pre>
 
@@ -961,21 +961,21 @@ as there is no dedicated Target assigned to triples containing
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -1069,21 +1069,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -1168,21 +1168,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -1267,21 +1267,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 
@@ -1372,21 +1372,21 @@ are exported to `TargetDump2`.
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nq&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nq&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nq&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nq&gt;;
 .
 </pre>
 

--- a/spec/section/overriding-targets.md
+++ b/spec/section/overriding-targets.md
@@ -102,21 +102,21 @@ http://dbpedia.org/resource/Melissa_Rauch,Melissa Rauch
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump2&gt;;
+  rml:target &lt;#DCATDump2&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump2.nq&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump2.nq&gt;;
 .
 </pre>
 
@@ -259,21 +259,21 @@ http://dbpedia.org/resource/Melissa_Rauch,Melissa Rauch
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 &lt;#TargetDump2&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump2&gt;;
+  rml:target &lt;#DCATDump2&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
-&lt;#VoIDDump2&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump2.nt&gt;;
+&lt;#DCATDump2&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump2.nt&gt;;
 .
 </pre>
 

--- a/spec/section/overview.md
+++ b/spec/section/overview.md
@@ -19,7 +19,7 @@ and provides fine-grained control over where each RDF triple is exported to.
 
 Logical Source and Logical Target leverage
 the access descriptions of data access 
-such as DCAT [[DCAT]], VoID [[VoID]], SD [[SD]], etc. 
+such as DCAT [[DCAT]], SD [[SD]], etc. 
 
 In this document, examples assume 
 the following namespace prefix bindings unless otherwise stated:
@@ -28,7 +28,6 @@ the following namespace prefix bindings unless otherwise stated:
 | --------- | --------------------------------------------------- |
 | `rml`     | http://w3id.org/rml/                                |
 | `formats` | http://www.w3.org/ns/formats/                       |
-| `void`    | http://rdfs.org/ns/void#                            |
 | `sd`      | http://www.w3.org/ns/sparql-service-description#    |
 | `dcat`    | http://www.w3.org/ns/dcat#                          |
 | `td`      | https://www.w3.org/2019/wot/td#                     |

--- a/spec/section/single-targets.md
+++ b/spec/section/single-targets.md
@@ -81,14 +81,14 @@ to an RDF dump with N-Quads as serialization format and GZip compression:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Quads;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nq.gz&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nq.gz&gt;;
   rml:compression rml:gzip;
 .
 </pre>
@@ -183,14 +183,14 @@ with Turtle as serialization format and Zip compression:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:Turtle;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset;
-  void:dataDump &lt;file:///data/dump1.ttl.zip&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution;
+  dcat:downloadURL &lt;file:///data/dump1.ttl.zip&gt;;
   rml:compression rml:zip;
 .
 </pre>
@@ -302,14 +302,14 @@ with N-Triples as serialization format:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
 </pre>
 
@@ -420,13 +420,13 @@ to an RDF dump with N-Quads as serialization format:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nq&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nq&gt;;
 .
 </pre>
 
@@ -523,14 +523,14 @@ to a RDF dump with N-Triples as serialization format:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
 </pre>
 
@@ -632,14 +632,14 @@ to a RDF dump with N-Triples as serialization format:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Triples;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nt&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nt&gt;;
 .
 </pre>
 
@@ -741,14 +741,14 @@ to a RDF dump with N-Triples as serialization format:
 
 <pre class="ex-target">
 &lt;#TargetDump1&gt; a rml:LogicalTarget;
-  rml:target &lt;#VoIDDump1&gt;;
+  rml:target &lt;#DCATDump1&gt;;
   rml:serialization formats:N-Quads;
 .
 </pre>
 
 <pre class="ex-access">
-&lt;#VoIDDump1&gt; a rml:Target, void:Dataset ;
-  void:dataDump &lt;file:///data/dump1.nq.gz&gt;;
+&lt;#DCATDump1&gt; a rml:Target, dcat:Distribution ;
+  dcat:downloadURL &lt;file:///data/dump1.nq.gz&gt;;
   rml:compression rml:gzip;
 .
 </pre>

--- a/spec/section/target-vocabulary.md
+++ b/spec/section/target-vocabulary.md
@@ -22,7 +22,7 @@ all other properties are optional.
 ### Target 
 
 A Target describes how a target must be accessed when exporting RDF triples.
-An external vocabulary such as DCAT, VoID, SD is allowed here. 
+An external vocabulary such as DCAT, SD, etc. is allowed here. 
 If a target cannot be accessed with existing vocabulary, a custom vocabulary 
 can be used, for example: handling an authentication flow may be specific 
 for that specific target. A custom ontology can be used here to describe 
@@ -138,9 +138,9 @@ The following example show a Target of an RDF dump in Turtle [[Turtle]]
 format with GZip compression and UTF-8 encoding:
 
 <pre class="ex-target">
-&lt;#VoIDDump&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, void:Dataset;
-        void:dataDump &lt;file:///data/dump.ttl&gt;;
+&lt;#DCATDump&gt; a rml:LogicalTarget;
+    rml:target [ a rml:Target, dcat:Distribution;
+        dcat:downloadURL &lt;file:///data/dump.ttl&gt;;
         rml:compression rml:gzip;
         rml:encoding rml:UTF-8;
     ];

--- a/test-cases/RMLSTC0003/mapping.ttl
+++ b/test-cases/RMLSTC0003/mapping.ttl
@@ -1,6 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 

--- a/test-cases/RMLSTC0006b/mapping.ttl
+++ b/test-cases/RMLSTC0006b/mapping.ttl
@@ -1,11 +1,11 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
-@prefix void: <http://rdfs.org/ns/void#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
-<#VoIDSourceAccess> a rml:Source, void:Dataset;
-  void:dataDump <http://w3id.org/rml/resources/rml-io/RMLSTC0006b/Friends.nt>;
+<#VoIDSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0006b/Friends.nt>;
 .
 
 <#TriplesMap> a rml:TriplesMap;

--- a/test-cases/RMLTTC0001a/mapping.ttl
+++ b/test-cases/RMLTTC0001a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0001b/mapping.ttl
+++ b/test-cases/RMLTTC0001b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0001c/mapping.ttl
+++ b/test-cases/RMLTTC0001c/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0001d/mapping.ttl
+++ b/test-cases/RMLTTC0001d/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org/> .
 @base <http://example.com/rules/> .
@@ -42,8 +41,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0001e/mapping.ttl
+++ b/test-cases/RMLTTC0001e/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -41,8 +40,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0001f/mapping.ttl
+++ b/test-cases/RMLTTC0001f/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
@@ -42,8 +41,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002a/mapping.ttl
+++ b/test-cases/RMLTTC0002a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002b/mapping.ttl
+++ b/test-cases/RMLTTC0002b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002c/mapping.ttl
+++ b/test-cases/RMLTTC0002c/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002d/mapping.ttl
+++ b/test-cases/RMLTTC0002d/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002e/mapping.ttl
+++ b/test-cases/RMLTTC0002e/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -40,22 +39,22 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump3> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump3.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump3.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002f/mapping.ttl
+++ b/test-cases/RMLTTC0002f/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org> .
 @base <http://example.com/rules/> .
@@ -43,15 +42,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002g/mapping.ttl
+++ b/test-cases/RMLTTC0002g/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org> .
 @base <http://example.com/rules/> .
@@ -43,15 +42,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002h/mapping.ttl
+++ b/test-cases/RMLTTC0002h/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org> .
 @base <http://example.com/rules/> .
@@ -43,15 +42,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002i/mapping.ttl
+++ b/test-cases/RMLTTC0002i/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org> .
 @base <http://example.com/rules/> .
@@ -46,15 +45,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002j/mapping.ttl
+++ b/test-cases/RMLTTC0002j/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org> .
 @base <http://example.com/rules/> .
@@ -43,15 +42,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002k/mapping.ttl
+++ b/test-cases/RMLTTC0002k/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix ex: <http://example.org> .
@@ -47,15 +46,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002l/mapping.ttl
+++ b/test-cases/RMLTTC0002l/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix ex: <http://example.org> .
@@ -44,15 +43,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002m/mapping.ttl
+++ b/test-cases/RMLTTC0002m/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002n/mapping.ttl
+++ b/test-cases/RMLTTC0002n/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,15 +38,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002o/mapping.ttl
+++ b/test-cases/RMLTTC0002o/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org/> .
 @base <http://example.com/rules/> .
@@ -46,8 +45,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002p/mapping.ttl
+++ b/test-cases/RMLTTC0002p/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -53,15 +52,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002q/mapping.ttl
+++ b/test-cases/RMLTTC0002q/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
@@ -54,15 +53,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0002r/mapping.ttl
+++ b/test-cases/RMLTTC0002r/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -39,8 +38,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0003a/mapping.ttl
+++ b/test-cases/RMLTTC0003a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -50,15 +49,15 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .
 
 <#TargetDump2> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump2.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0004a/mapping.ttl
+++ b/test-cases/RMLTTC0004a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.jsonld>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.jsonld>;
   ];
   rml:serialization formats:JSON-LD;
 .

--- a/test-cases/RMLTTC0004b/mapping.ttl
+++ b/test-cases/RMLTTC0004b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.n3>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.n3>;
   ];
   rml:serialization formats:N3;
 .

--- a/test-cases/RMLTTC0004c/mapping.ttl
+++ b/test-cases/RMLTTC0004c/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nt>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nt>;
   ];
   rml:serialization formats:N-Triples;
 .

--- a/test-cases/RMLTTC0004d/mapping.ttl
+++ b/test-cases/RMLTTC0004d/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0004e/mapping.ttl
+++ b/test-cases/RMLTTC0004e/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.rdfjson>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.rdfjson>;
   ];
   rml:serialization formats:RDF_JSON;
 .

--- a/test-cases/RMLTTC0004f/mapping.ttl
+++ b/test-cases/RMLTTC0004f/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.rdfxml>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.rdfxml>;
   ];
   rml:serialization formats:RDF_XML;
 .

--- a/test-cases/RMLTTC0004g/mapping.ttl
+++ b/test-cases/RMLTTC0004g/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.ttl>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.ttl>;
   ];
   rml:serialization formats:Turtle;
 .

--- a/test-cases/RMLTTC0005a/mapping.ttl
+++ b/test-cases/RMLTTC0005a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
   rml:encoding rml:UTF-8;

--- a/test-cases/RMLTTC0005b/mapping.ttl
+++ b/test-cases/RMLTTC0005b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
   rml:encoding rml:UTF-16;

--- a/test-cases/RMLTTC0006a/mapping.ttl
+++ b/test-cases/RMLTTC0006a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .

--- a/test-cases/RMLTTC0006b/mapping.ttl
+++ b/test-cases/RMLTTC0006b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq.gz>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.gz>;
   ];
   rml:serialization formats:N-Quads;
   rml:compression rml:gzip;

--- a/test-cases/RMLTTC0006c/mapping.ttl
+++ b/test-cases/RMLTTC0006c/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq.zip>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.zip>;
   ];
   rml:serialization formats:N-Quads;
   rml:compression rml:zip;

--- a/test-cases/RMLTTC0006d/mapping.ttl
+++ b/test-cases/RMLTTC0006d/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @prefix ex: <http://example.org/> .
 @base <http://example.com/rules/> .
@@ -39,8 +38,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq.tar.xz>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.tar.xz>;
   ];
   rml:serialization formats:N-Quads;
   rml:compression rml:tarxz;

--- a/test-cases/RMLTTC0006e/mapping.ttl
+++ b/test-cases/RMLTTC0006e/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq.tar.gz>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.tar.gz>;
   ];
   rml:serialization formats:N-Quads;
   rml:compression rml:targz;

--- a/test-cases/RMLTTC0007a/mapping.ttl
+++ b/test-cases/RMLTTC0007a/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 

--- a/test-cases/RMLTTC0007b/mapping.ttl
+++ b/test-cases/RMLTTC0007b/mapping.ttl
@@ -1,7 +1,6 @@
 @prefix rml: <http://w3id.org/rml/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
-@prefix void: <http://rdfs.org/ns/void#> .
 @prefix formats: <http://www.w3.org/ns/formats/> .
 @base <http://example.com/rules/> .
 
@@ -38,8 +37,8 @@
 .
 
 <#TargetDump1> a rml:LogicalTarget;
-  rml:target [ a rml:Target, void:Dataset;
-    void:dataDump <file://./dump1.nq>;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
   ];
   rml:serialization formats:N-Quads;
 .


### PR DESCRIPTION
DCAT covers everything of VOID, let's use DCT in the spec.
VOID still works, but let's not confuse developers with both.

Fixes https://github.com/kg-construct/rml-io/issues/67