### PR TITLE
spec: section: source-vocabulary: drop non-chartered and RML-Core reference formulations

### DIFF
--- a/spec/dev.html
+++ b/spec/dev.html
@@ -251,15 +251,17 @@
             name: "Dylan Van Assche",
             mailto: "dylan.vanassche@ugent.be",
             company: "IDLab &ndash; Ghent University &ndash; imec",
-            orcidid: "0000-0002-7195-9935",
-            companyURL: "http://idlab.technology/"
-          },
+            orcid: "0000-0002-7195-9935",
+            companyURL: "https://knows.idlab.ugent.be/"
+          }
+        ],
+        formerEditors: [
           {
             name: "Anastasia Dimou",
-            mailto: "anastasia.dimou@kuleuven.be",
-            company: "KU Leuven, Department of Computer Science",
-            orcidid: "0000-0003-2138-7972",
-            companyURL: "https://wms.cs.kuleuven.be/cs/english/"
+            url: "https://natadimou.com/#me",
+            orcid: "0000-0003-2138-7972",
+            company: "KU Leuven",
+            companyURL: "https://dtai.cs.kuleuven.be/"
           }
         ],
         group: "kg-construct",

--- a/spec/dev.html
+++ b/spec/dev.html
@@ -250,6 +250,7 @@
           {
             name: "Dylan Van Assche",
             mailto: "dylan.vanassche@ugent.be",
+	    url: "https://dylanvanassche.be",
             company: "IDLab &ndash; Ghent University &ndash; imec",
             orcid: "0000-0002-7195-9935",
             companyURL: "https://knows.idlab.ugent.be/"

--- a/spec/section/source-vocabulary.md
+++ b/spec/section/source-vocabulary.md
@@ -66,26 +66,19 @@ Several <a data-cite="RML-Core#dfn-reference-formulation">reference formulation<
 
 - `rml:CSV`: CSV or TSV data sources
 - `rml:JSONPath`: JSON documents
-- `rml:XPath`: XML documents, a shortcut for `rml:XPathReferenceFormulation`
-with default parameters
-- `rml:XPathReferenceFormulation`: XML documents with optionally
+- `rml:XPath`: XML documents with optionally
 the definition of XML namespaces used in references.
 By default, no namespaces are defined.
 - `rml:SQL2008Query`: SQL query for a relational database.
 - `rml:SQL2008Table`: Shortcut to select all columns from a SQL table.
 
-`rml:XPathReferenceFormulation` may specify zero or more
+`rml:XPath` may specify zero or more
 `rml:namespace` properties with a `rml:Namespace`.
 A `rml:Namespace` contains the following required properties:
  - `rml:namespacePrefix`: A Literal with the prefix used for the XML namespace.
  - `rml:namespaceURL`: A Literal with the URL identifying the XML namespace.
 
-SPARQL queries iterations can be specified by using the W3C Formats namespace:
-
-- `formats:SPARQL_Results_CSV`: SPARQL results as CSV.
-- `formats:SPARQL_Results_TSV`: SPARQL results as TSV.
-- `formats:SPARQL_Results_JSON`: SPARQL results as JSON.
-- `formats:SPARQL_Results_XML`: SPARQL results as XML.
+These reference formulations are defined in the [[RML-IO-Registry]].
 
 <pre class="ex-source">
 &lt;#XMLNamespace&gt; a rml:LogicalSource;
@@ -237,162 +230,8 @@ A shortcut is available to select all columns from a table,
 such as in the example above, by using the `rml:SQL2008Table`
 as `rml:referenceFormulation`.
 
-The following example shows a [=Source=] of a
-XML file with no compression.
-
-<pre class="ex-source">
-&lt;#XML&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, dcat:Distribution;
-        dcat:accessURL &lt;file:///path/to/data.xml&gt;;
-    ];
-    rml:referenceFormulation rml:XPath;
-    rml:iterator "/xpath/iterator/expression";
-.
-</pre>
-
-The following example is GZip compressed JSON file as [=Source=]:
-
-<pre class="ex-source">
-&lt;#JSON&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, dcat:Distribution;
-        dcat:accessURL &lt;file:///path/to/data.json.gz&gt;;
-        rml:compression rml:gzip;
-     ];
-     rml:referenceFormulation rml:JSONPath;
-     rml:iterator "$.jsonpath.expression";
-.
-</pre>
-
-[=Sources=] MAY also describe access to SPARQL endpoints with the
-W3C Service Description ontology. SPARQL endpoints need a SPARQL query,
-to iterate over.
-
-<pre class="ex-source">
-&lt;#SPARQLEndpoint&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, sd:Service;
-        sd:endpoint  &lt;http://example.com/sparql&gt;;
-        sd:supportedLanguage sd:SPARQL11Query;
-    ];
-    rml:iterator "SELECT { s? ?p ?o } WHERE { ?s ?p ?o. } LIMIT 100";
-    rml:referenceFormulation formats:SPARQL_Results_CSV;
-.
-</pre>
-
-Web APIs and streams are supported through the W3C Web of Things ontologies:
-- HTTP Web API
-- MQTT streams
-- CoAP
-- Kafka
-- HTTP Server Sent Events
-
-The following example is a HTTP JSON Web API with a HTTP header User Agent
-set to 'Processor':
-
-<pre class="ex-source">
-&lt;#HTTPWebAPI&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "http://localhost:4242/";
-                hctl:forContentType "application/json";
-                # Set HTTP method and headers through W3C WoT Binding Template for HTTP
-                htv:methodName "GET";
-                htv:headers ([
-                    htv:fieldName "User-Agent";
-                    htv:fieldValue "Processor";
-                ]);
-            ];
-        ];
-    ];
-    rml:referenceFormulation rml:JSONPath;
-    rml:iterator "$.jsonpath";
-.
-</pre>
-
-The following example shows a [=Source=] of a
-HTTP Server Sent Events stream in XML format without compression:
-
-<pre class="ex-source">
-&lt;#HTTPSSEStream&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "http://localhost:4242/";
-                hctl:forContentType "text/event-stream";
-            ];
-        ];
-    ];
-    rml:referenceFormulation rml:XPath;
-    rml:iterator "/my/xpath";
-.
-</pre>
-
-The following example shows a [=Source=] of a
-MQTT stream in JSON format without compression:
-
-<pre class="ex-source">
-&lt;#MQTTStream&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "mqtt://localhost/topic";
-                hctl:forContentType "application/json";
-                # Set MQTT parameters through W3C WoT Binding Template for MQTT
-                mqv:controlPacketValue "SUBSCRIBE";
-                mqv:options ([ mqv:optionName "qos"; mqv:optionValue "1" ] [ mqv:optionName "dup" ]);
-            ];
-        ];
-    ];
-    rml:referenceFormulation rml:JSONPath;
-    rml:iterator "$.jsonpath";
-.
-</pre>
-
-The following example shows a [=Source=] of a
-TCP stream in JSON format without compression:
-
-<pre class="ex-source">
-&lt;#TCPStream&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "tcp://localhost:1234/topic";
-                hctl:forContentType "application/json";
-            ];
-        ];
-    ];
-    rml:referenceFormulation rml:JSONPath;
-    rml:iterator "$.jsonpath";
-.
-</pre>
-
-The following example shows a [=Source=] of a
-Kafka stream in XML format without compression:
-
-<pre class="ex-source">
-&lt;#KafkaStream&gt; a rml:LogicalSource;
-    rml:source [ a rml:Source, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "kafka://localhost:8089/topic";
-                hctl:forContentType "application/xml";
-                # Kafka parameters through W3C WoT Binding Template for Kafka
-                kafka:groupId "MyAwesomeGroup";
-            ];
-        ];
-    ];
-    rml:referenceFormulation rml:XPath;
-    rml:iterator "/my/xpath";
-.
-</pre>
-
 Relative paths to files are covered by a source access description included
-in this specification which subclasses `rml:Source` as `rml:RelativePathSource`.
+in this specification which subclasses `rml:Source` as `rml:FilePath`.
 This access description allows accessing files relative from:
 
 - `rml:CurrentWorkingDirectory`: relative to the current working directory of the RML processor.
@@ -401,10 +240,10 @@ This access description allows accessing files relative from:
 
 If `rml:root` is not specified, it defaults to `rml:CurrentWorkingDirectory`.
 
-| Property    | Domain                    | Range                                                              |
-| ----------- | ------------------------- | ------------------------------------------------------------------ |
-| `rml:root`  | `rml:RelativePathSource`  | `rml:CurrentWorkingDirectory`, `rml:MappingDirectory` or `Literal` |
-| `rml:path`  | `rml:RelativePathSource`  | `Literal`                                                          |
+| Property    | Domain          | Range                                                              |
+| ----------- | --------------- | ------------------------------------------------------------------ |
+| `rml:root`  | `rml:FilePath`  | `rml:CurrentWorkingDirectory`, `rml:MappingDirectory` or `Literal` |
+| `rml:path`  | `rml:FilePath`  | `Literal`                                                          |
 
 Example of accessing a CSV file relative to the current working directory.
 The file's absolute path is `$CURRENT_WORKING_DIR/file.csv` where `$CURRENT_WORKING_DIR` is
@@ -412,7 +251,7 @@ the location of the RML mapping.
 
 <pre class="ex-source">
 &lt;#RelativePathCWD&gt; a rml:LogicalSource;
-  rml:source [ a rml:RelativePathSource, rml:Source;
+  rml:source [ a rml:FilePath, rml:Source;
     rml:root rml:CurrentWorkingDirectory;
     rml:path "./file.csv";
   ];
@@ -425,7 +264,7 @@ the location of the RML mapping.
 
 <pre class="ex-source">
 &lt;#RelativePathMapping&gt; a rml:LogicalSource;
-  rml:source [ a rml:RelativePathSource, rml:Source;
+  rml:source [ a rml:FilePath, rml:Source;
     rml:root rml:MappingDirectory;
     rml:path "./file.json";
   ];
@@ -439,7 +278,7 @@ specified by a string Literal. The file's absolute path is `/root/file.xml`.
 
 <pre class="ex-source">
 &lt;#RelativePathLiteral&gt; a rml:LogicalSource;
-  rml:source [ a rml:RelativePathSource, rml:Source;
+  rml:source [ a rml:FilePath, rml:Source;
     rml:root "/root";
     rml:path "file.xml";
   ];

--- a/spec/section/target-vocabulary.md
+++ b/spec/section/target-vocabulary.md
@@ -108,28 +108,7 @@ and MAY be extended in the future.
 #### Relative paths
 
 Relative paths to files are covered by a target access description included
-in this specification which subclasses `rml:Target` as `rml:RelativePathTarget`.
-This access description allows accessing files relative from:
-
-- `rml:CurrentWorkingDirectory`: relative to the current working directory of the RML processor.
-- `rml:MappingDirectory`: relative to the location of the RML mapping.
-- A string Literal: a string describing an absolute path against which relative paths are resolved, similar to the Base URI in [RFC3986](https://www.rfc-editor.org/rfc/rfc3986).
-
-If `rml:root` is not specified, it defaults to `rml:CurrentWorkingDirectory`.
-
-| Property    | Domain                    | Range                                                              |
-| ----------- | ------------------------- | ------------------------------------------------------------------ |
-| `rml:root`  | `rml:RelativePathSource`  | `rml:CurrentWorkingDirectory`, `rml:MappingDirectory` or `Literal` |
-| `rml:path`  | `rml:RelativePathSource`  | `Literal`                                                          |
-
-<pre class="ex-source">
-&lt;#RelativePathCWD&gt; a rml:LogicalTarget;
-  rml:target [ a rml:RelativePathTarget, rml:Target;
-    rml:root rml:CurrentWorkingDirectory;
-    rml:path "./file.ttl";
-  ];
-.
-</pre>
+in this specification which subclasses `rml:Target` as `rml:FilePath` re-used from the Logical Source.
 
 ### Examples {#target-examples}
 
@@ -137,168 +116,12 @@ The following example show a Target of an RDF dump in Turtle [[Turtle]]
 format with GZip compression and UTF-8 encoding:
 
 <pre class="ex-target">
-&lt;#DCATDump&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, dcat:Distribution;
-        dcat:downloadURL &lt;file:///data/dump.ttl&gt;;
+&lt;#FileDump&gt; a rml:LogicalTarget;
+    rml:target [ a rml:Target, rml:FilePath;
+        rml:path "/data/dump.ttl";
         rml:compression rml:gzip;
         rml:encoding rml:UTF-8;
     ];
     rml:serialization formats:Turtle;
-.
-</pre>
-
-The following example shows a Target of a [[SPARQL]]
-endpoint with `SPARQL UPDATE`:
-
-<pre class="ex-target">
-&lt;#SPARQLEndpoint&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, sd:Service;
-        sd:endpoint  &lt;http://example.com/sparql-update&gt;;
-        sd:supportedLanguage sd:SPARQL11Update ;
-    ];
-.
-</pre>
-
-The following example shows a Target of a
-DCAT dataset in N-Quads format with Zip compression:
-
-<pre class="ex-target">
-&lt;#DCATDump&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, dcat:Distribution;
-        dcat:accessURL &lt;http://example.org/dcat-access-url&gt;;
-        rml:compression rml:zip;
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-MQTT stream in N-Quads format without compression.
-Authentication is performed with a custom HTTP header called `apikey`
-with token value `123456789`. Token value is described by IDSA because
-WoT Security only describes the security information without providing a
-way to supply the actual value of username/password, tokens,  etc.
-For security reasons, these values should never be provided in the RML mapping
-by separating them in separate document.
-
-<pre class="ex-target">
-&lt;#MQTTStream&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [ a td:PropertyAffordance;
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "mqtt://localhost/topic";
-                hctl:forContentType "application/n-quads";
-                # Set MQTT parameters through W3C WoT Binding Template for MQTT
-                mqv:controlPacketValue "SUBSCRIBE";
-                mqv:options ([ mqv:optionName "qos"; mqv:optionValue "1" ] [ mqv:optionName "dup" ]);
-            ];
-        ];
-        td:hasSecurityConfiguration [ a wotsec:APIKeySecurityScheme, idsa:Token;
-          wotsec:in "header";
-          wotsec:name "apikey";
-          idsa:tokenValue "123456789"
-        ];
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-TCP stream in N-Quads format without compression.
-
-<pre class="ex-target">
-&lt;#TCPStream&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "tcp://localhost:1234/topic";
-                hctl:forContentType "application/n-quads";
-            ];
-        ];
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-Kafka stream in N-Quads format without compression:
-
-<pre class="ex-target">
-&lt;#KafkaStream&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "kafka://localhost:8089/topic";
-                hctl:forContentType "application/n-quads";
-                # Kafka parameters through W3C WoT Binding Template for Kafka
-                kafka:groupId "MyAwesomeGroup";
-            ];
-        ];
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-HTTP Web API in N-Quads format without compression and
-the User Agent HTTP header set to 'Processor':
-
-<pre class="ex-target">
-&lt;#HTTPWebAPI&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "http://localhost:4242/";
-                hctl:forContentType "application/n-quads";
-                # Set HTTP method and headers through W3C WoT Binding Template for HTTP
-                htv:methodName "POST";
-                htv:headers ([
-                    htv:fieldName "User-Agent";
-                    htv:fieldValue "Processor";
-                ]);
-            ];
-        ];
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-HTTP Server Sent Events stream in N-Quads format without compression:
-
-<pre class="ex-target">
-&lt;#HTTPSSEStream&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "http://localhost:4242/";
-                hctl:forContentType "text/event-stream";
-            ];
-        ];
-    ];
-    rml:serialization formats:N-Quads;
-.
-</pre>
-
-The following example shows a Target of a
-WebSocket in N-Quads format without compression:
-
-<pre class="ex-target">
-&lt;#HTTPSSEStream&gt; a rml:LogicalTarget;
-    rml:target [ a rml:Target, td:Thing;
-        td:hasPropertyAffordance [
-            td:hasForm [
-                # URL and content type
-                hctl:hasTarget "ws://localhost:5555/";
-                hctl:forContentType "application/n-quads";
-            ];
-        ];
-    ];
-    rml:serialization formats:N-Quads;
 .
 </pre>

--- a/test-cases/RMLSTC0001a/README.md
+++ b/test-cases/RMLSTC0001a/README.md
@@ -1,0 +1,94 @@
+# RMLSTC0001a
+
+Test source with UTF-8 encoding
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0001a/Friends.json>;
+  rml:encoding rml:UTF-8;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0001b/README.md
+++ b/test-cases/RMLSTC0001b/README.md
@@ -1,0 +1,94 @@
+# RMLSTC0001b
+
+Test source with UTF-16 encoding
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0001b/Friends-UTF16.json>;
+  rml:encoding rml:UTF-16;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0002a/README.md
+++ b/test-cases/RMLSTC0002a/README.md
@@ -1,0 +1,93 @@
+# RMLSTC0002a
+
+Test source without compression
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0002a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0002b/README.md
+++ b/test-cases/RMLSTC0002b/README.md
@@ -1,0 +1,65 @@
+# RMLSTC0002b
+
+Test source with GZip compression
+
+**Error expected?** Yes
+
+**Input**
+ `Friends.json.gz`
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0002b/Friends.json.gz>;
+  rml:compression rml:gzip;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0002c/README.md
+++ b/test-cases/RMLSTC0002c/README.md
@@ -1,0 +1,65 @@
+# RMLSTC0002c
+
+Test source with ZIP compression
+
+**Error expected?** Yes
+
+**Input**
+ `Friends.json.zip`
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0002c/Friends.json.zip>;
+  rml:compression rml:zip;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0002d/README.md
+++ b/test-cases/RMLSTC0002d/README.md
@@ -1,0 +1,65 @@
+# RMLSTC0002d
+
+Test source with TarXZ compression
+
+**Error expected?** Yes
+
+**Input**
+ `Friends.json.tar.xz`
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0002d/Friends.json.tar.xz>;
+  rml:compression rml:tarxz;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0002e/README.md
+++ b/test-cases/RMLSTC0002e/README.md
@@ -1,0 +1,65 @@
+# RMLSTC0002e
+
+Test source with TarGZip compression
+
+**Error expected?** Yes
+
+**Input**
+ `Friends.json.tar.gz`
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0002e/Friends.json.tar.gz>;
+  rml:compression rml:targz;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0003/README.md
+++ b/test-cases/RMLSTC0003/README.md
@@ -1,0 +1,82 @@
+# RMLSTC0003
+
+Test source which requires a query
+
+**Error expected?** Yes
+
+**Input**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source [ a rml:RelativePathSource;
+        rml:path "./Friends.nt";
+    ];
+    rml:iterator """
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+    SELECT ?person ?name ?age WHERE {
+        ?person foaf:name ?name .
+        ?person foaf:age ?age .
+    }
+    """;
+    rml:referenceFormulation formats:SPARQL_Results_CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:reference "person";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0004a/README.md
+++ b/test-cases/RMLSTC0004a/README.md
@@ -1,0 +1,80 @@
+# RMLSTC0004a
+
+Test source with default NULL values
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+5;;
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0004a/Friends-NULL.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+<http://example.org/5> <http://xmlns.com/foaf/0.1/age> "" .
+<http://example.org/5> <http://xmlns.com/foaf/0.1/name> "" .
+
+```
+

--- a/test-cases/RMLSTC0004b/README.md
+++ b/test-cases/RMLSTC0004b/README.md
@@ -1,0 +1,80 @@
+# RMLSTC0004b
+
+Test source with one NULL value defined
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+5;;
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0004b/Friends-NULL.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+  # Empty value is considered NULL
+  rml:null "";
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0004c/README.md
+++ b/test-cases/RMLSTC0004c/README.md
@@ -1,0 +1,82 @@
+# RMLSTC0004c
+
+Test source with multiple NULL values defined
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+5;;
+6;NULL;NULL
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0004c/Friends-NULL2.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+  # Empty value and 'NULL' are both considered NULL
+  rml:null "";
+  rml:null "NULL";
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0005a/README.md
+++ b/test-cases/RMLSTC0005a/README.md
@@ -1,0 +1,81 @@
+# RMLSTC0005a
+
+Test source with data access description providing NULL values which we override.
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+5;;
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0005a/Friends-NULL.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+    csvw:null "NULL";
+  ];
+  # Empty value is considered NULL and overrides CSVW
+  rml:null "";
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0005b/README.md
+++ b/test-cases/RMLSTC0005b/README.md
@@ -1,0 +1,79 @@
+# RMLSTC0005b
+
+Test source with data access description providing encoding which we override.
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0005b/Friends.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+  # Encoding is UTF-16 and overrides CSVW
+  rml:encoding rml:UTF-16;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006a/README.md
+++ b/test-cases/RMLSTC0006a/README.md
@@ -1,0 +1,93 @@
+# RMLSTC0006a
+
+Test source with DCAT data access description
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0006a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006b/README.md
+++ b/test-cases/RMLSTC0006b/README.md
@@ -1,0 +1,85 @@
+# RMLSTC0006b
+
+Test source with VoID data access description
+
+**Error expected?** Yes
+
+**Input**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#VoIDSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0006b/Friends.nt>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#VoIDSourceAccess>;
+    rml:iterator """
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+    SELECT ?id ?name ?age WHERE {
+        ?person foaf:name ?name .
+        ?person foaf:age ?age .
+        BIND(REPLACE(STR(?person),"http://example.org/", "") AS ?id) .
+    }
+    """;
+    rml:referenceFormulation formats:SPARQL_Results_CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006c/README.md
+++ b/test-cases/RMLSTC0006c/README.md
@@ -1,0 +1,86 @@
+# RMLSTC0006c
+
+Test source with SD data access description
+
+**Error expected?** Yes
+
+**Input**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#SDSourceAccess> a rml:Source, sd:Service;
+  sd:endpoint <http://example.com/sparql/>;
+  sd:supportedLanguage sd:SPARQL11Query;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#SDSourceAccess>;
+    rml:iterator """
+    PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+    SELECT ?id ?name ?age WHERE {
+        ?person foaf:name ?name .
+        ?person foaf:age ?age .
+        BIND(REPLACE(STR(?person),"http://example.org/", "") AS ?id) .
+    }
+    """;
+    rml:referenceFormulation formats:SPARQL_Results_CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006d/README.md
+++ b/test-cases/RMLSTC0006d/README.md
@@ -1,0 +1,77 @@
+# RMLSTC0006d
+
+Test source with CSVW data access description
+
+**Error expected?** Yes
+
+**Input**
+```
+id;name;age
+0;Monica Geller;33
+1;Rachel Green;34
+2;Joey Tribbiani;35
+3;Chandler Bing;36
+4;Ross Geller;37
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0006d/Friends.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006e/README.md
+++ b/test-cases/RMLSTC0006e/README.md
@@ -1,0 +1,101 @@
+# RMLSTC0006e
+
+Test source with Web of Things data access description
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@base <http://example.com/rules/> .
+
+<#WoTSourceAccess> a rml:Source, td:Thing;
+  td:hasPropertyAffordance [
+    td:hasForm [
+      # URL and content type
+      hctl:hasTarget "http://w3id.org/rml/resources/rml-io/RMLSTC0006e/Friends.json";
+      hctl:forContentType "application/json";
+    ];
+  ];
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#WoTSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0006f/README.md
+++ b/test-cases/RMLSTC0006f/README.md
@@ -1,0 +1,75 @@
+# RMLSTC0006f
+
+Test source with D2RQ access description for SQL databases
+
+**Error expected?** Yes
+
+**Input**
+```
+id, name, age
+0, Monica Geller, 33
+1, Rachel Green, 34
+2, Joey Tribbiani, 35
+3, Chandler Bing, 36
+4, Ross Geller, 37
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix d2rq: <http://www.wiwiss.fu-berlin.de/suhl/bizer/D2RQ/0.1#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#D2RQSourceAccess> a rml:Source, d2rq:Database;
+  d2rq:jdbcDSN "$CONNECTIONDSN";
+  d2rq:username "$USERNAME";
+  d2rq:password "$PASSWORD"
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#D2RQSourceAccess>;
+    rml:referenceFormulation rml:SQL2008Table;
+    rml:iterator "Friends";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0007a/README.md
+++ b/test-cases/RMLSTC0007a/README.md
@@ -1,0 +1,94 @@
+# RMLSTC0007a
+
+Test source with JSONPath reference formulation
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0007a/Friends.json>;
+  rml:encoding rml:UTF-8;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0007b/README.md
+++ b/test-cases/RMLSTC0007b/README.md
@@ -1,0 +1,77 @@
+# RMLSTC0007b
+
+Test source with Tabular reference formulation
+
+**Error expected?** Yes
+
+**Input**
+```
+id; name; age
+0; Monica Geller; 33
+1; Rachel Green; 34
+2; Joey Tribbiani; 35
+3; Chandler Bing; 36
+4; Ross Geller; 37
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix csvw: <http://www.w3.org/ns/csvw#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@base <http://example.com/rules/> .
+
+<#CSVWSourceAccess> a rml:Source, csvw:Table;
+  csvw:url "http://w3id.org/rml/resources/rml-io/RMLSTC0007b/Friends.csv"^^xsd:anyURI ;
+  csvw:dialect [ a csvw:Dialect;
+    csvw:delimiter ";";
+    csvw:encoding "UTF-8";
+    csvw:header "1"^^xsd:boolean;
+  ];
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#CSVWSourceAccess>;
+    rml:referenceFormulation rml:CSV;
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0007c/README.md
+++ b/test-cases/RMLSTC0007c/README.md
@@ -1,0 +1,88 @@
+# RMLSTC0007c
+
+Test source with XPath reference formulation
+
+**Error expected?** Yes
+
+**Input**
+```
+<Friends>
+  <Character id="0">
+    <name>Monica Geller</name>
+    <age>33</age>
+  </Character>
+  <Character id="1">
+    <name>Rachel Green</name>
+    <age>34</age>
+  </Character>
+  <Character id="2">
+    <name>Joey Tribbiani</name>
+    <age>35</age>
+  </Character>
+  <Character id="3">
+    <name>Chandler Bing</name>
+    <age>36</age>
+  </Character>
+  <Character id="4">
+    <name>Ross Geller</name>
+    <age>37</age>
+  </Character>
+</Friends>
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0007c/Friends.xml>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:XPath;
+    rml:iterator "//Friends/Character";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{@id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "name/text()";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "age/text()";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLSTC0007d/README.md
+++ b/test-cases/RMLSTC0007d/README.md
@@ -1,0 +1,93 @@
+# RMLSTC0007d
+
+Test source with XPath reference formulation with namespaces
+
+**Error expected?** Yes
+
+**Input**
+```
+<Friends xmlns:ex="http://example.org">
+  <ex:Character id="0">
+    <ex:name>Monica Geller</ex:name>
+    <ex:age>33</ex:age>
+  </ex:Character>
+  <ex:Character id="1">
+    <ex:name>Rachel Green</ex:name>
+    <ex:age>34</ex:age>
+  </ex:Character>
+  <ex:Character id="2">
+    <ex:name>Joey Tribbiani</ex:name>
+    <ex:age>35</ex:age>
+  </ex:Character>
+  <ex:Character id="3">
+    <ex:name>Chandler Bing</ex:name>
+    <ex:age>36</ex:age>
+  </ex:Character>
+  <ex:Character id="4">
+    <ex:name>Ross Geller</ex:name>
+    <ex:age>37</ex:age>
+  </ex:Character>
+</Friends>
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+  dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLSTC0007d/Friends.xml>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation [ a rml:XPathReferenceFormulation;
+      rml:namespace [ a rml:Namespace;
+        rml:namespacePrefix "ex";
+        rml:namespaceURL "http://example.org";
+      ];
+    ];
+    rml:iterator "//Friends/ex:Character";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{@id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "ex:name/text()";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "ex:age/text()";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0000/README.md
+++ b/test-cases/RMLTTC0000/README.md
@@ -1,0 +1,93 @@
+# RMLTTC0000
+
+Test exporting all triples to the default Target when not Targets are specified.
+
+**Error expected?** Yes
+
+**Input**
+```
+[
+  { 
+    "id": 0,
+    "name": "Monica Geller",
+    "age": 33
+  },
+  { 
+    "id": 1,
+    "name": "Rachel Green",
+    "age": 34
+  },
+  { 
+    "id": 2,
+    "name": "Joey Tribbiani",
+    "age": 35
+  },
+  { 
+    "id": 3,
+    "name": "Chandler Bing",
+    "age": 36
+  },
+  { 
+    "id": 4,
+    "name": "Ross Geller",
+    "age": 37
+  }
+]
+
+```
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0000/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+```
+
+**Output**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0001a/README.md
+++ b/test-cases/RMLTTC0001a/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0001a
+
+Test exporting all triples to a single Target with a given subject.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0001b/README.md
+++ b/test-cases/RMLTTC0001b/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0001b
+
+Test exporting all triples to a single Target with a given predicate.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0001c/README.md
+++ b/test-cases/RMLTTC0001c/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0001c
+
+Test exporting all triples to a single Target with a given object reference.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001c/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001c/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001c/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0001d/README.md
+++ b/test-cases/RMLTTC0001d/README.md
@@ -1,0 +1,82 @@
+# RMLTTC0001d
+
+Test exporting all triples within a named graph to a single Target.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001d/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001d/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001d/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph>.
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0001e/README.md
+++ b/test-cases/RMLTTC0001e/README.md
@@ -1,0 +1,81 @@
+# RMLTTC0001e
+
+Test exporting all triples with a given language tag to a single Target.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001e/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001e/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001e/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:languageMap [ a rml:LanguageMap;
+        rml:constant "en";
+        rml:logicalTarget <#TargetDump1>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller"@en .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green"@en .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani"@en .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing"@en .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller"@en .
+
+```
+

--- a/test-cases/RMLTTC0001f/README.md
+++ b/test-cases/RMLTTC0001f/README.md
@@ -1,0 +1,82 @@
+# RMLTTC0001f
+
+Test exporting all triples with a given datatype to a single Target.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0001f/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0001f/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0001f/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:datatypeMap [ a rml:DatatypeMap;
+        rml:constant xsd:integer;
+        rml:logicalTarget <#TargetDump1>;
+      ];
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.
+
+```
+

--- a/test-cases/RMLTTC0002a/README.md
+++ b/test-cases/RMLTTC0002a/README.md
@@ -1,0 +1,101 @@
+# RMLTTC0002a
+
+Test exporting all triples to multiple Targets in the same Term Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+    rml:logicalTarget <#TargetDump2>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0002b/README.md
+++ b/test-cases/RMLTTC0002b/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002b
+
+Test exporting all triples to a Target in a Subject Map and a Target in a Predicate Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+      rml:logicalTarget <#TargetDump2>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002c/README.md
+++ b/test-cases/RMLTTC0002c/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002c
+
+Test exporting all triples to a Target in a Subject Map and a Target in a Object Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002c/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002c/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002c/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump2>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002d/README.md
+++ b/test-cases/RMLTTC0002d/README.md
@@ -1,0 +1,91 @@
+# RMLTTC0002d
+
+Test exporting all triples to a Target in a Predicate Map and a Target in a Object Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002d/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002d/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002d/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump2>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002e/README.md
+++ b/test-cases/RMLTTC0002e/README.md
@@ -1,0 +1,99 @@
+# RMLTTC0002e
+
+Test exporting all triples to a Target in a Subject Map, a Target in a Predicate Map, and a Target in a Object Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002e/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002e/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002e/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump3>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump2>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump3> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump3.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002f/README.md
+++ b/test-cases/RMLTTC0002f/README.md
@@ -1,0 +1,100 @@
+# RMLTTC0002f
+
+Test exporting all triples to a Target in a Subject Map and a Target in a Graph Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002f/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002f/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002f/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph;
+      rml:logicalTarget <#TargetDump2>;
+    ];
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph>.
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0002g/README.md
+++ b/test-cases/RMLTTC0002g/README.md
@@ -1,0 +1,95 @@
+# RMLTTC0002g
+
+Test exporting all triples to a Target in a Predicate Map and a Target in a Graph Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002g/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002g/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002g/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph;
+      rml:logicalTarget <#TargetDump2>;
+    ];
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0002h/README.md
+++ b/test-cases/RMLTTC0002h/README.md
@@ -1,0 +1,95 @@
+# RMLTTC0002h
+
+Test exporting all triples to a Target in a Object Map and a Target in a Graph Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002h/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002h/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002h/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph;
+      rml:logicalTarget <#TargetDump2>;
+    ];
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0002i/README.md
+++ b/test-cases/RMLTTC0002i/README.md
@@ -1,0 +1,98 @@
+# RMLTTC0002i
+
+Test exporting all triples to a Target in a Language Map and a Target in a Graph Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002i/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002i/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002i/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:languageMap [ a rml:LanguageMap;
+        rml:constant "en";
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph; 
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller"@en .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green"@en .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani"@en .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing"@en .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller"@en .
+
+```
+

--- a/test-cases/RMLTTC0002j/README.md
+++ b/test-cases/RMLTTC0002j/README.md
@@ -1,0 +1,95 @@
+# RMLTTC0002j
+
+Test exporting all triples to a Target in a Language Map and a Target in a Object Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002j/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002j/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002j/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:languageMap [ a rml:LanguageMap;
+        rml:constant "en";
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller"@en .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green"@en .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani"@en .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing"@en .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller"@en .
+
+```
+

--- a/test-cases/RMLTTC0002k/README.md
+++ b/test-cases/RMLTTC0002k/README.md
@@ -1,0 +1,99 @@
+# RMLTTC0002k
+
+Test exporting all triples to a Target in a Datatype Map and a Target in a Graph Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002k/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002k/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002k/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph; 
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:datatypeMap [ a rml:DatatypeMap;
+        rml:constant xsd:integer;
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0002l/README.md
+++ b/test-cases/RMLTTC0002l/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002l
+
+Test exporting all triples to a Target in a Datatype Map and a Target in a Object Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002l/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002l/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://example.org> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002l/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:datatypeMap [ a rml:DatatypeMap;
+        rml:constant xsd:integer;
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> <http://example.org/PeopleGraph> .
+
+```
+

--- a/test-cases/RMLTTC0002m/README.md
+++ b/test-cases/RMLTTC0002m/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002m
+
+Test exporting all triples to Targets in multiple Predicate Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002m/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002m/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002m/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+      rml:logicalTarget <#TargetDump2>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002n/README.md
+++ b/test-cases/RMLTTC0002n/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002n
+
+Test exporting all triples to Targets in multiple Object Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002n/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002n/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002n/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:logicalTarget <#TargetDump2>;
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0002o/README.md
+++ b/test-cases/RMLTTC0002o/README.md
@@ -1,0 +1,96 @@
+# RMLTTC0002o
+
+Test exporting all triples to Targets in multiple Graph Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002o/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002o/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002o/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph1;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+    rml:graphMap [ a rml:GraphMap;
+      rml:constant ex:PeopleGraph1;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" <http://example.org/PeopleGraph1>.
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph1> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" <http://example.org/PeopleGraph1> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph1> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" <http://example.org/PeopleGraph1> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph1> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" <http://example.org/PeopleGraph1> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph1> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" <http://example.org/PeopleGraph1> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph1> .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" <http://example.org/PeopleGraph2> .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" <http://example.org/PeopleGraph2> .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" <http://example.org/PeopleGraph2> .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" <http://example.org/PeopleGraph2> .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" <http://example.org/PeopleGraph2> .
+
+```
+

--- a/test-cases/RMLTTC0002p/README.md
+++ b/test-cases/RMLTTC0002p/README.md
@@ -1,0 +1,110 @@
+# RMLTTC0002p
+
+Test exporting all triples to Targets in multiple Language Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002p/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002p/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002p/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:languageMap [ a rml:LanguageMap;
+        rml:constant "en";
+        rml:logicalTarget <#TargetDump1>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+      rml:languageMap [ a rml:LanguageMap;
+        rml:constant "nl";
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller"@en .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green"@en .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani"@en .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing"@en .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller"@en .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller"@nl .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green"@nl .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani"@nl .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing"@nl .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller"@nl .
+
+```
+

--- a/test-cases/RMLTTC0002q/README.md
+++ b/test-cases/RMLTTC0002q/README.md
@@ -1,0 +1,111 @@
+# RMLTTC0002q
+
+Test exporting all triples to Targets in multiple Datatype Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002q/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002q/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002q/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:datatypeMap [ a rml:DatatypeMap;
+        rml:constant xsd:integer;
+        rml:logicalTarget <#TargetDump1>;
+      ];
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+      rml:datatypeMap [ a rml:DatatypeMap;
+        rml:constant xsd:double;
+        rml:logicalTarget <#TargetDump2>;
+      ];
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#double>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#double>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#double>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#double>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#double>.
+
+```
+

--- a/test-cases/RMLTTC0002r/README.md
+++ b/test-cases/RMLTTC0002r/README.md
@@ -1,0 +1,84 @@
+# RMLTTC0002r
+
+Test exporting all triples to same Target in multiple Term Maps.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0002r/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0002r/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0002r/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+      rml:logicalTarget <#TargetDump1>;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0003a/README.md
+++ b/test-cases/RMLTTC0003a/README.md
@@ -1,0 +1,102 @@
+# RMLTTC0003a
+
+Test exporting some triples to a different Target with a separate Triples Map.
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0003a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0003a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0003a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TriplesMap2> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+<#TargetDump2> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump2.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+
+**Output 3**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+
+```
+

--- a/test-cases/RMLTTC0004a/README.md
+++ b/test-cases/RMLTTC0004a/README.md
@@ -1,0 +1,101 @@
+# RMLTTC0004a
+
+Test export all triples as JSON-LD
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.jsonld>;
+  ];
+  rml:serialization formats:JSON-LD;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+{
+  "@context": { 
+    "foaf": "http://xmlns.com/foaf/0.1/"
+  },
+  "@graph": [
+    {                                                                                
+
+      "@id": "http://example.org/0",
+      "foaf:name": "Monica Geller",
+      "foaf:age": "33"
+    },
+    {                                                                                
+      "@id": "http://example.org/1",
+      "foaf:name": "Rachel Green",
+      "foaf:age": "34"
+    },
+    {                                                                                
+      "@id": "http://example.org/2",
+      "foaf:name": "Joey Tribbiani",
+      "foaf:age": "35"
+    },
+    {                                                                                
+      "@id": "http://example.org/3",
+      "foaf:name": "Chandler Bing",
+      "foaf:age": "36"
+    },
+      {                                                                                
+      "@id": "http://example.org/4",
+      "foaf:name": "Ross Geller",
+      "foaf:age": "37"
+    }
+  ]
+}
+
+```
+

--- a/test-cases/RMLTTC0004b/README.md
+++ b/test-cases/RMLTTC0004b/README.md
@@ -1,0 +1,80 @@
+# RMLTTC0004b
+
+Test export all triples as N3
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.n3>;
+  ];
+  rml:serialization formats:N3;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.org/> .
+ex:0 <foaf:age> "33" ;
+     <foaf:name> "Monica Geller" .
+ex:1 <foaf:age> "34" ;
+     <foaf:name> "Rachel Green" .
+ex:2 <foaf:age> "35" ;
+     <foaf:name> "Joey Tribbiani" .
+ex:3 <foaf:age> "36" ;
+     <foaf:name> "Chandler Bing" .
+ex:4 <foaf:age> "37" ;
+     <foaf:name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0004c/README.md
+++ b/test-cases/RMLTTC0004c/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0004c
+
+Test export all triples as N-Triples
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004c/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004c/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004c/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nt>;
+  ];
+  rml:serialization formats:N-Triples;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0004d/README.md
+++ b/test-cases/RMLTTC0004d/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0004d
+
+Test export all triples as N-Quads
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004d/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004d/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004d/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0004e/README.md
+++ b/test-cases/RMLTTC0004e/README.md
@@ -1,0 +1,90 @@
+# RMLTTC0004e
+
+Test export all triples as RDF/JSON
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004e/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004e/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004e/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.rdfjson>;
+  ];
+  rml:serialization formats:RDF_JSON;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+{
+    "http://example.org/0" : {
+        "http://xmlns.com/foaf/0.1/age" : [ { "value" : "33" } ],
+        "http://xmlns.com/foaf/0.1/name" : [ { "value" : "Monica Geller" } ]
+    },
+    "http://example.org/1" : {
+        "http://xmlns.com/foaf/0.1/age" : [ { "value" : "34" } ],
+        "http://xmlns.com/foaf/0.1/name" : [ { "value" : "Rachel Green" } ]
+    },
+    "http://example.org/2" : {
+        "http://xmlns.com/foaf/0.1/age" : [ { "value" : "35" } ],
+        "http://xmlns.com/foaf/0.1/name" : [ { "value" : "Joey Tribbiani" } ]
+    },
+    "http://example.org/3" : {
+        "http://xmlns.com/foaf/0.1/age" : [ { "value" : "36" } ],
+        "http://xmlns.com/foaf/0.1/name" : [ { "value" : "Chandler Bing" } ]
+    },
+    "http://example.org/4" : {
+        "http://xmlns.com/foaf/0.1/age" : [ { "value" : "37" } ],
+        "http://xmlns.com/foaf/0.1/name" : [ { "value" : "Ross Geller" } ]
+    }
+}
+
+```
+

--- a/test-cases/RMLTTC0004f/README.md
+++ b/test-cases/RMLTTC0004f/README.md
@@ -1,0 +1,91 @@
+# RMLTTC0004f
+
+Test export all triples as RDF/XML
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004f/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004f/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004f/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.rdfxml>;
+  ];
+  rml:serialization formats:RDF_XML;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/">
+  <rdf:Description rdf:about="http://example.org/0">
+    <foaf:age>33</foaf:age>
+    <foaf:name>Monica Geller</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://example.org/1">
+    <foaf:age>34</foaf:age>
+    <foaf:name>Rachel Green</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://example.org/2">
+    <foaf:age>35</foaf:age>
+    <foaf:name>Joey Tribbiani</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://example.org/3">
+    <foaf:age>36</foaf:age>
+    <foaf:name>Chandler Bing</foaf:name>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://example.org/4">
+    <foaf:age>37</foaf:age>
+    <foaf:name>Ross Geller</foaf:name>
+  </rdf:Description>
+</rdf:RDF>
+
+```
+

--- a/test-cases/RMLTTC0004g/README.md
+++ b/test-cases/RMLTTC0004g/README.md
@@ -1,0 +1,81 @@
+# RMLTTC0004g
+
+Test export all triples as Turtle
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0004g/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0004g/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0004g/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.ttl>;
+  ];
+  rml:serialization formats:Turtle;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix ex: <http://example.org/> .
+
+<ex:0> <foaf:age> "33" .
+<ex:0> <foaf:name> "Monica Geller" .
+<ex:1> <foaf:age> "34" .
+<ex:1> <foaf:name> "Rachel Green" .
+<ex:2> <foaf:age> "35" .
+<ex:2> <foaf:name> "Joey Tribbiani" .
+<ex:3> <foaf:age> "36" .
+<ex:3> <foaf:name> "Chandler Bing" .
+<ex:4> <foaf:age> "37" .
+<ex:4> <foaf:name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0005a/README.md
+++ b/test-cases/RMLTTC0005a/README.md
@@ -1,0 +1,79 @@
+# RMLTTC0005a
+
+Test export all triples with UTF-8 encoding
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0005a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0005a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0005a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:encoding rml:UTF-8;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0005b/README.md
+++ b/test-cases/RMLTTC0005b/README.md
@@ -1,0 +1,79 @@
+# RMLTTC0005b
+
+Test export all triples with UTF-16 encoding
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0005b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0005b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0005b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:encoding rml:UTF-16;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0006a/README.md
+++ b/test-cases/RMLTTC0006a/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0006a
+
+Test export all triples with no compression
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0006a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0006a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0006a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0006b/README.md
+++ b/test-cases/RMLTTC0006b/README.md
@@ -1,0 +1,67 @@
+# RMLTTC0006b
+
+Test export all triples with GZip compression
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0006b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0006b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0006b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.gz>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:compression rml:gzip;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+ `dump1.nq.gz`
+

--- a/test-cases/RMLTTC0006c/README.md
+++ b/test-cases/RMLTTC0006c/README.md
@@ -1,0 +1,67 @@
+# RMLTTC0006c
+
+Test export all triples with ZIP compression
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0006c/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0006c/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0006c/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.zip>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:compression rml:zip;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+ `dump1.nq.zip`
+

--- a/test-cases/RMLTTC0006d/README.md
+++ b/test-cases/RMLTTC0006d/README.md
@@ -1,0 +1,68 @@
+# RMLTTC0006d
+
+Test export all triples with TarXZ compression
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0006d/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0006d/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@prefix ex: <http://example.org/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0006d/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.tar.xz>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:compression rml:tarxz;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+ `dump1.nq.tar.xz`
+

--- a/test-cases/RMLTTC0006e/README.md
+++ b/test-cases/RMLTTC0006e/README.md
@@ -1,0 +1,67 @@
+# RMLTTC0006e
+
+Test export all triples with TarGZip compression
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0006e/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0006e/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0006e/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq.tar.gz>;
+  ];
+  rml:serialization formats:N-Quads;
+  rml:compression rml:targz;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+ `dump1.nq.tar.gz`
+

--- a/test-cases/RMLTTC0007a/README.md
+++ b/test-cases/RMLTTC0007a/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0007a
+
+Test export all triples to a target with DCAT access description
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0007a/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0007a/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0007a/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:accessUrl <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0007b/README.md
+++ b/test-cases/RMLTTC0007b/README.md
@@ -1,0 +1,78 @@
+# RMLTTC0007b
+
+Test export all triples to a target with VoID access description
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0007b/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0007b/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0007b/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, dcat:Distribution;
+    dcat:downloadURL <file://./dump1.nq>;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0007c/README.md
+++ b/test-cases/RMLTTC0007c/README.md
@@ -1,0 +1,80 @@
+# RMLTTC0007c
+
+Test export all triples to a target with SD access description
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0007c/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0007c/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0007c/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, sd:Service;
+    sd:endpoint  <http://example.com/sparql-update>;
+    sd:supportedLanguage sd:SPARQL11Update;
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0007d/README.md
+++ b/test-cases/RMLTTC0007d/README.md
@@ -1,0 +1,86 @@
+# RMLTTC0007d
+
+Test export all triples to a target with Web of Things access description
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0007d/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0007d/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0007d/Friends.json>;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, td:Thing;
+      td:hasPropertyAffordance [
+        td:hasForm [
+          hctl:hasTarget "http://localhost/data";
+          hctl:forContentType "application/n-quads";
+      ];
+    ];
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/RMLTTC0007e/README.md
+++ b/test-cases/RMLTTC0007e/README.md
@@ -1,0 +1,87 @@
+# RMLTTC0007e
+
+Test dcat:format in a Target
+
+**Error expected?** Yes
+
+**Input**
+ [http://w3id.org/rml/resources/rml-io/RMLTTC0007e/Friends.json](http://w3id.org/rml/resources/rml-io/RMLTTC0007e/Friends.json)
+
+**Mapping**
+```
+@prefix rml: <http://w3id.org/rml/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix td: <https://www.w3.org/2019/wot/td#> .
+@prefix htv: <http://www.w3.org/2011/http#> .
+@prefix hctl: <https://www.w3.org/2019/wot/hypermedia#> .
+@prefix formats: <http://www.w3.org/ns/formats/> .
+@base <http://example.com/rules/> .
+
+<#DCATSourceAccess> a rml:Source, dcat:Distribution;
+    dcat:downloadURL <http://w3id.org/rml/resources/rml-io/RMLTTC0007d/Friends.json>;
+    dcat:format <http://www.iana.org/assignments/media-types/application/json> ;
+.
+
+<#TriplesMap> a rml:TriplesMap;
+  rml:logicalSource [ a rml:LogicalSource;
+    rml:source <#DCATSourceAccess>;
+    rml:referenceFormulation rml:JSONPath;
+    rml:iterator "$[*]";
+  ];
+  rml:subjectMap [ a rml:SubjectMap;
+    rml:template "http://example.org/{$.id}";
+    rml:logicalTarget <#TargetDump1>;
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:name;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.name";
+    ];
+  ];
+  rml:predicateObjectMap [ a rml:PredicateObjectMap;
+    rml:predicateMap [ a rml:PredicateMap;
+      rml:constant foaf:age;
+    ];
+    rml:objectMap [ a rml:ObjectMap;
+      rml:reference "$.age";
+    ];
+  ];
+.
+
+<#TargetDump1> a rml:LogicalTarget;
+  rml:target [ a rml:Target, td:Thing;
+      td:hasPropertyAffordance [
+        td:hasForm [
+          hctl:hasTarget "http://localhost/data";
+          hctl:forContentType "application/n-quads";
+      ];
+    ];
+  ];
+  rml:serialization formats:N-Quads;
+.
+
+```
+
+**Output 1**
+```
+
+```
+
+**Output 2**
+```
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
+
+```
+

--- a/test-cases/config.js
+++ b/test-cases/config.js
@@ -1,0 +1,72 @@
+async function loadTurtle() {
+  //this is the function you call in 'preProcess', to load the highlighter
+  const worker = await new Promise(resolve => {
+    require(["core/worker"], ({ worker }) => resolve(worker));
+  });
+  const action = "highlight-load-lang";
+  const langURL =
+    "https://cdn.jsdelivr.net/gh/redmer/highlightjs-turtle/src/languages/turtle.js";
+  const propName = "hljsDefineTurtle"; // This funtion is defined in the highlighter being loaded
+  const lang = "turtle"; // this is the class you use to identify the language
+  worker.postMessage({ action, langURL, propName, lang });
+  return new Promise(resolve => {
+    worker.addEventListener("message", function listener({ data }) {
+      const { action: responseAction, lang: responseLang } = data;
+      if (responseAction === action && responseLang === lang) {
+        worker.removeEventListener("message", listener);
+        resolve();
+      }
+    });
+  });
+}
+
+var respecConfig = {
+  // check https://respec.org/docs/ for the meaning of these keys
+  preProcess: [loadTurtle],
+  authors: [
+    {
+      name: "Dylan Van Assche",
+      url: "https://dylanvanassche.be",
+      company: "IDLab &ndash; Ghent University &ndash; imec",
+      orcid: "0000-0002-7195-9935",
+      companyURL: "https://knows.idlab.ugent.be/"
+    }
+  ],
+  edDraftURI: "https://w3id.org/rml/io/test-cases/",
+  editors: [
+    {
+      name: "Dylan Van Assche",
+      url: "https://dylanvanassche.be",
+      company: "IDLab &ndash; Ghent University &ndash; imec",
+      orcid: "0000-0002-7195-9935",
+      companyURL: "https://knows.idlab.ugent.be/"
+    }
+  ],
+  formerEditors: [
+  ],
+  github: "https://github.com/kg-construct/rml-io",
+  license: "w3c-software-doc",
+  localBiblio: {
+    "RML-Core": {
+      title: "RML-Core",
+      href: "https://w3id.org/rml/core/spec",
+      status: "Draft Community Group Report",
+      publisher: "W3C",
+      date: "07 August 2024",
+    },
+    "RML-IO": {
+      title: "RML-IO",
+      href: "https://w3id.org/rml/io/spec",
+      status: "Draft Community Group Report",
+      publisher: "W3C",
+      date: "12 March 2024",
+    },
+  },
+  otherLinks: [],
+  shortName: "RML-IO-Testcases",
+  specStatus: "CG-DRAFT",
+  // W3C config
+  copyrightStart: "2024",
+  doJsonLd: true,
+  group: "kg-construct",
+};

--- a/test-cases/index.html
+++ b/test-cases/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <title>RML-IO: Test Cases</title>
+    <meta charset="utf-8">
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
+    <style type="text/css">
+        /* Adapted from R2RML */
+        aside.ex-input,
+        aside.ex-mapping,
+        aside.ex-output {
+            word-wrap:normal;
+            margin-top: 1.5em;
+            padding: 1em;
+            font-size: 80%;
+        }
+        aside.ex-input:before,
+        aside.ex-mapping:before,
+        aside.ex-output:before {
+            background: white;
+            display: block;
+            font-family: sans-serif;
+            font-size: 90%;
+            margin: -1.5em 0 0.5em 0;
+            padding: 0.4em 0.4em;
+            width: 18em;
+        }
+        /* Input data example */
+        aside.ex-input {
+            background: #cee;
+        }
+        aside.ex-input,
+        aside.ex-input:before {
+            border: 1px solid #acc;
+            overflow: auto;
+        }
+        aside.ex-input:before {
+            content: "Example input data";
+        }
+        /* RML mapping example */
+        aside.ex-mapping {
+            background: #eeb;
+        }
+        aside.ex-mapping,
+        aside.ex-mapping:before {
+            border: 1px solid #cc9;
+            overflow: auto;
+        }
+        aside.ex-mapping:before {
+            content: "Example RML mapping";
+        }
+        /* Output RDF example */
+        aside.ex-output {
+            background: #cfc;
+        }
+        aside.ex-output,
+        aside.ex-output:before {
+            border: 1px solid #aca;
+            overflow: auto;
+        }
+        aside.ex-output:before {
+            content: "Example output data";
+        }
+        table, th, td {
+          background: white;
+          border-collapse: collapse;
+          border: 1px solid;
+        }
+        th, td {
+          padding: 5px;
+          text-align: left;
+        }
+        th {
+          font-weight: bold;
+        }
+    </style>
+    <script src = config.js class="remove">
+    </script>
+</head>
+
+<body>
+<script src="https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.min.js"></script>
+<script>mermaid.initialize({startOnLoad:true});</script>
+
+<section id="abstract" data-include="section/abstract.md" data-include-format="markdown"></section>
+
+<section id="sotd"></section>
+
+<section id="introduction" data-include="section/introduction.md" data-include-format="markdown"></section>
+
+<section id="data-model" data-include="section/data-model.md" data-include-format="markdown"></section>
+
+<section id="test-cases" data-include="section/test-cases.md" data-include-format="markdown"></section>
+
+<!-- Generated with list.sh -->
+<section id="RMLSTC0001a" data-include="RMLSTC0001a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0001b" data-include="RMLSTC0001b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0002a" data-include="RMLSTC0002a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0002b" data-include="RMLSTC0002b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0002c" data-include="RMLSTC0002c/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0002d" data-include="RMLSTC0002d/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0002e" data-include="RMLSTC0002e/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0003" data-include="RMLSTC0003/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0004a" data-include="RMLSTC0004a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0004b" data-include="RMLSTC0004b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0004c" data-include="RMLSTC0004c/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0005a" data-include="RMLSTC0005a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0005b" data-include="RMLSTC0005b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006a" data-include="RMLSTC0006a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006b" data-include="RMLSTC0006b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006c" data-include="RMLSTC0006c/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006d" data-include="RMLSTC0006d/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006e" data-include="RMLSTC0006e/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0006f" data-include="RMLSTC0006f/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0007a" data-include="RMLSTC0007a/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0007b" data-include="RMLSTC0007b/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0007c" data-include="RMLSTC0007c/README.md" data-include-format=markdown></section>
+<section id="RMLSTC0007d" data-include="RMLSTC0007d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0000" data-include="RMLTTC0000/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001a" data-include="RMLTTC0001a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001b" data-include="RMLTTC0001b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001c" data-include="RMLTTC0001c/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001d" data-include="RMLTTC0001d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001e" data-include="RMLTTC0001e/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0001f" data-include="RMLTTC0001f/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002a" data-include="RMLTTC0002a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002b" data-include="RMLTTC0002b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002c" data-include="RMLTTC0002c/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002d" data-include="RMLTTC0002d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002e" data-include="RMLTTC0002e/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002f" data-include="RMLTTC0002f/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002g" data-include="RMLTTC0002g/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002h" data-include="RMLTTC0002h/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002i" data-include="RMLTTC0002i/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002j" data-include="RMLTTC0002j/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002k" data-include="RMLTTC0002k/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002l" data-include="RMLTTC0002l/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002m" data-include="RMLTTC0002m/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002n" data-include="RMLTTC0002n/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002o" data-include="RMLTTC0002o/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002p" data-include="RMLTTC0002p/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002q" data-include="RMLTTC0002q/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0002r" data-include="RMLTTC0002r/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0003a" data-include="RMLTTC0003a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004a" data-include="RMLTTC0004a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004b" data-include="RMLTTC0004b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004c" data-include="RMLTTC0004c/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004d" data-include="RMLTTC0004d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004e" data-include="RMLTTC0004e/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004f" data-include="RMLTTC0004f/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0004g" data-include="RMLTTC0004g/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0005a" data-include="RMLTTC0005a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0005b" data-include="RMLTTC0005b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0006a" data-include="RMLTTC0006a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0006b" data-include="RMLTTC0006b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0006c" data-include="RMLTTC0006c/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0006d" data-include="RMLTTC0006d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0006e" data-include="RMLTTC0006e/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0007a" data-include="RMLTTC0007a/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0007b" data-include="RMLTTC0007b/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0007c" data-include="RMLTTC0007c/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0007d" data-include="RMLTTC0007d/README.md" data-include-format=markdown></section>
+<section id="RMLTTC0007e" data-include="RMLTTC0007e/README.md" data-include-format=markdown></section>
+
+</body>
+
+</html>

--- a/test-cases/list.sh
+++ b/test-cases/list.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+for i in RML*; do
+	echo "<section id=\"$i\" data-include=\"$i/README.md\" data-include-format="markdown"></section>"
+done

--- a/test-cases/make-metadata.py
+++ b/test-cases/make-metadata.py
@@ -133,6 +133,73 @@ def main(spec: str):
                              output_format1, output_format2, output_format3,
                              input1, input2, input3, output1, output2,
                              output3, error])
+            lines = []
+            # Title and description
+            lines.append(f'# {testcase}\n\n')
+            lines.append(f'{description}\n\n')
+            if error:
+                error_html = 'Yes'
+            else:
+                error_html = 'No'
+            lines.append(f'**Error expected?** {error_html}\n\n')
+
+            # Input
+            inputCount = ''
+
+            for index, i in enumerate([input1, input2, input3]):
+                if not i:
+                    break
+
+                if 'http://w3id.org/rml/resources' in i:
+                    input_html = f'**Input{inputCount}**\n [{i}]({i})\n\n'
+                else:
+                    try:
+                        with open(os.path.join(testcase, i)) as f:
+                            input_html = f'**Input{inputCount}**\n```\n{f.read()}\n```\n\n'
+                    except UnicodeDecodeError:
+                        try:
+                            with open(os.path.join(testcase, i), encoding='utf-16') as f:
+                                input_html = f'**Input{inputCount}**\n```\n{f.read()}\n```\n\n'
+                        except UnicodeDecodeError:
+                            input_html = f'**Input{inputCount}**\n `{i}`\n\n'
+
+                lines.append(input_html)
+                inputCount = f' {index + 1}'
+
+            # Mapping
+            with open(os.path.join(testcase, mapping_file)) as f:
+                mapping_html = f'**Mapping**\n```\n{f.read()}\n```\n\n'
+                lines.append(mapping_html)
+
+            # Output
+            outputCount = ''
+            if output2 or output3:
+                outputCount = ' 1'
+
+            for index, i in enumerate([output1, output2, output3]):
+                if not i:
+                    break
+
+                if 'http://w3id.org/rml/resources' in i:
+                    output_html = f'**Output{outputCount}**\n [{i}]({i})\n\n'
+                else:
+                    try:
+                        with open(os.path.join(testcase, i)) as f:
+                            output_html = f'**Output{outputCount}**\n```\n{f.read()}\n```\n\n'
+                    except UnicodeDecodeError:
+                        try:
+                            with open(os.path.join(testcase, i), encoding='utf-16') as f:
+                                output_html = f'**Output{outputCount}**\n```\n{f.read()}\n```\n\n'
+                        except UnicodeDecodeError:
+                            output_html = f'**Output{outputCount}**\n `{i}`\n\n'
+
+                lines.append(output_html)
+                outputCount = f' {index + 2}'
+
+
+            with open(os.path.join(testcase, 'README.md'), 'w') as f:
+                f.writelines(lines)
+
 
 if __name__ == '__main__':
     if len(sys.argv) != 2:

--- a/test-cases/section/abstract.md
+++ b/test-cases/section/abstract.md
@@ -1,0 +1,1 @@
+This document defines the RML-IO test cases to the determine the RML-IO specification conformance of tools.

--- a/test-cases/section/data-model.md
+++ b/test-cases/section/data-model.md
@@ -1,0 +1,12 @@
+# Data model
+
+The test cases are semantically described for re-usability and shareability following the [W3C Test case description](https://www.w3.org/2006/03/test-description).
+Each `test:Testcase` as the following properties:
+
+- `dcterms:identifier`: unique ID of the test case.
+- `rmltest:hasError`: if an error of the RML Processor is expected or not.
+- `rmltest:input`: One or more input data of the test case.
+- `rmltest:output`: One or more output data of the test case.
+- `rmltest:inputFormat`: the input data format.
+- `rmltest:outputFormat`: the output data format.
+- `rmltest:mappingDocument`: the RML mapping rules in Turtle.

--- a/test-cases/section/introduction.md
+++ b/test-cases/section/introduction.md
@@ -1,0 +1,4 @@
+# Introduction
+
+This document defines the RML-IO test cases, consisting of a collection of test case documents (input and expected output).
+The purpose of the test cases is to determine the conformance of tools that execute RML rules to the RML-IO specification. 

--- a/test-cases/section/test-cases.md
+++ b/test-cases/section/test-cases.md
@@ -1,0 +1,10 @@
+# Test cases
+
+This section describes the RML-IO test cases. These descriptions are also available as RDF.
+The files are available on [GitHub](https://github.com/kg-construct/rml-io/tree/main/test-cases) in the folder `test-cases`.
+Each test case is contained in a single folder, containing three types of files:
+
+ - Zero or more files containing the data sources, in the case of JSON, XML, CSV, or containing the SQL statements to create the necessary tables, in the case of MySQL, PostgreSQL, and SQL Server.
+ - One file with the RML rules, called `mapping.ttl`, in the Turtle format.
+ - Zero or more files with the expected RDF. No file is provided if an error is expected that must halt the generation of the RDF because of an error.
+


### PR DESCRIPTION
CSV+JSONPath is required by RML-Core, rest is in IO registry.

Related to https://github.com/kg-construct/rml-core/pull/152