### PR TITLE
fix: Add xsd datatypes to output triples due to natural mapping

### DIFF
--- a/test-cases/RMLSTC0001a/default.nq
+++ b/test-cases/RMLSTC0001a/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0001b/default.nq
+++ b/test-cases/RMLSTC0001b/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0002a/default.nq
+++ b/test-cases/RMLSTC0002a/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0002b/default.nq
+++ b/test-cases/RMLSTC0002b/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0002c/default.nq
+++ b/test-cases/RMLSTC0002c/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0002d/default.nq
+++ b/test-cases/RMLSTC0002d/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0002e/default.nq
+++ b/test-cases/RMLSTC0002e/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0003/default.nq
+++ b/test-cases/RMLSTC0003/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0004a/default.nq
+++ b/test-cases/RMLSTC0004a/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0004b/default.nq
+++ b/test-cases/RMLSTC0004b/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0004c/default.nq
+++ b/test-cases/RMLSTC0004c/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0006a/default.nq
+++ b/test-cases/RMLSTC0006a/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0006b/default.nq
+++ b/test-cases/RMLSTC0006b/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0007a/default.nq
+++ b/test-cases/RMLSTC0007a/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0007b/default.nq
+++ b/test-cases/RMLSTC0007b/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0007c/default.nq
+++ b/test-cases/RMLSTC0007c/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0007d/default.nq
+++ b/test-cases/RMLSTC0007d/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLSTC0008a/default.nq
+++ b/test-cases/RMLSTC0008a/default.nq
@@ -1,12 +1,12 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
-<http://example.org/6> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/6> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/6> <http://xmlns.com/foaf/0.1/name> "Phoebe Buffay" .

--- a/test-cases/RMLSTC0008b/default.nq
+++ b/test-cases/RMLSTC0008b/default.nq
@@ -1,12 +1,12 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .
-<http://example.org/6> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/6> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/6> <http://xmlns.com/foaf/0.1/name> "Phoebe Buffay" .

--- a/test-cases/RMLTTC0000/default.nq
+++ b/test-cases/RMLTTC0000/default.nq
@@ -1,10 +1,10 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33" .
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/0> <http://xmlns.com/foaf/0.1/name> "Monica Geller" .
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34" .
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/1> <http://xmlns.com/foaf/0.1/name> "Rachel Green" .
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35" .
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/2> <http://xmlns.com/foaf/0.1/name> "Joey Tribbiani" .
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36" .
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/3> <http://xmlns.com/foaf/0.1/name> "Chandler Bing" .
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37" .
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer> .
 <http://example.org/4> <http://xmlns.com/foaf/0.1/name> "Ross Geller" .

--- a/test-cases/RMLTTC0001b/default.nq
+++ b/test-cases/RMLTTC0001b/default.nq
@@ -1,5 +1,5 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLTTC0001c/default.nq
+++ b/test-cases/RMLTTC0001c/default.nq
@@ -1,5 +1,5 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLTTC0001e/default.nq
+++ b/test-cases/RMLTTC0001e/default.nq
@@ -1,5 +1,5 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.

--- a/test-cases/RMLTTC0002p/default.nq
+++ b/test-cases/RMLTTC0002p/default.nq
@@ -1,5 +1,5 @@
-<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33".
-<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34".
-<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35".
-<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36".
-<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37".
+<http://example.org/0> <http://xmlns.com/foaf/0.1/age> "33"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/1> <http://xmlns.com/foaf/0.1/age> "34"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/2> <http://xmlns.com/foaf/0.1/age> "35"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/3> <http://xmlns.com/foaf/0.1/age> "36"^^<http://www.w3.org/2001/XMLSchema#integer>.
+<http://example.org/4> <http://xmlns.com/foaf/0.1/age> "37"^^<http://www.w3.org/2001/XMLSchema#integer>.


### PR DESCRIPTION
Added  `<http://www.w3.org/2001/XMLSchema#integer>` as datatypes to all triples in the expected output files of test cases. 

Fixes #139